### PR TITLE
Make both the input and output text regions select-all on focus.

### DIFF
--- a/Source/common.js
+++ b/Source/common.js
@@ -10,3 +10,14 @@ Array.from(inputTexts).forEach((inputText) => {
         inputText.select();
     });
 });
+var editableCodeAreas = document.querySelectorAll("code[contenteditable=true]");
+Array.from(editableCodeAreas).forEach((editableCodeArea) => {
+    editableCodeArea.addEventListener("focus", (ev) => {
+        // See https://stackoverflow.com/questions/6139107/programmatically-select-text-in-a-contenteditable-html-element/6150060#6150060
+        var range = document.createRange();
+        range.selectNodeContents(editableCodeArea);
+        var sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+    });
+});

--- a/Source/index.html
+++ b/Source/index.html
@@ -184,7 +184,7 @@
     <p>Made by <a href="https://twitter.com/lloydi" aria-label="Lloydi (Twitter)">Lloydi</a></p>
     <p><a href="https://github.com/lloydi/markup-de-crapulator">View this on GitHub</a> or <a href="https://github.com/lloydi/markup-de-crapulator/issues">file an issue</a> if there's something you'd like to see it do.</p>
   </body>
-  <script src="../common.js"></script>
+  <script src="common.js"></script>
   <script src="indent.js"></script>
   <script src="highlight/highlight.pack.js"></script>
   <script src="de-crapulator.js"></script>


### PR DESCRIPTION
Fix the reference to "common.js" so that the input textarea automatically selects all the content when it receives focus, and add JS to do the same with the formatted output area.